### PR TITLE
Fix: Remove invalid sample_rate argument from faster-whisper transcribe call

### DIFF
--- a/src/claude_stt/engines/whisper.py
+++ b/src/claude_stt/engines/whisper.py
@@ -62,7 +62,7 @@ class WhisperEngine:
         try:
             if audio.dtype != np.float32:
                 audio = audio.astype(np.float32)
-            segments, _info = self._model.transcribe(audio, sample_rate=sample_rate)
+            segments, _info = self._model.transcribe(audio)
             text = " ".join(segment.text.strip() for segment in segments)
             return text.strip()
         except Exception:


### PR DESCRIPTION
## Summary
  
- Remove invalid `sample_rate` keyword argument from `WhisperModel.transcribe()` call
- Fixes whisper engine failing with `TypeError: WhisperModel.transcribe() got an unexpected keyword
  argument 'sample_rate'`

## Problem
  
When using the whisper engine, transcription fails immediately with: 
`TypeError: WhisperModel.transcribe() got an unexpected keyword argument 'sample_rate'`

The `faster-whisper` library's `WhisperModel.transcribe()` method doesn't accept a `sample_rate`  parameter - it expects audio to already be at 16kHz (which the recorder provides).

## Test plan

- [x] Switch to whisper engine (`engine = "whisper"` in config)
- [x] Use hotkey to record and transcribe speech
- [x] Verify transcription completes without errors