### PR TITLE
Add PipeWire (pw-play) support for Linux sound playback

### DIFF
--- a/src/claude_stt/sounds.py
+++ b/src/claude_stt/sounds.py
@@ -1,6 +1,7 @@
 """Audio feedback using native system sounds."""
 
 import logging
+import os
 import platform
 import shutil
 import subprocess
@@ -76,8 +77,8 @@ def _play_linux_sound(event: SoundEvent) -> None:
         _logger.debug("Sound file missing: %s", sound_file)
         return
 
-    # Try pw-play first (PipeWire native)
-    if shutil.which("pw-play"):
+    # Try pw-play first (PipeWire native) when the PipeWire socket is present
+    if shutil.which("pw-play") and _pipewire_socket_available():
         subprocess.Popen(
             ["pw-play", sound_file],
             stdout=subprocess.DEVNULL,
@@ -101,6 +102,17 @@ def _play_linux_sound(event: SoundEvent) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+
+
+def _pipewire_socket_available() -> bool:
+    runtime_dir = os.environ.get("PIPEWIRE_RUNTIME_DIR") or os.environ.get("XDG_RUNTIME_DIR")
+    if not runtime_dir:
+        return False
+    remote = os.environ.get("PIPEWIRE_REMOTE", "pipewire-0")
+    remote_path = Path(remote)
+    if not remote_path.is_absolute():
+        remote_path = Path(runtime_dir) / remote
+    return remote_path.exists()
 
 
 def _play_windows_sound(event: SoundEvent) -> None:


### PR DESCRIPTION
## Summary

On modern Linux distributions using PipeWire as the audio server, `paplay` may not be available while `pw-play` is the native tool. This adds `pw-play` as the preferred sound player for Linux.

**Problem**: On PipeWire-based systems without PulseAudio compatibility layer, sounds either don't play or fall back to `aplay`, which cannot properly decode `.oga` (Ogg Vorbis) files—resulting in static noise instead of the intended sound.

**Solution**: Add `pw-play` as the first option in the fallback chain:
1. `pw-play` (PipeWire native)
2. `paplay` (PulseAudio)
3. `aplay` (ALSA - with note about .oga limitation)

## Test plan

- [x] Tested on Ubuntu with PipeWire - sounds play correctly
- [x] Backwards compatible - existing paplay/aplay setups unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)