### PR TITLE
Fix Linux background hotkeys

### DIFF
--- a/src/claude_stt/daemon.py
+++ b/src/claude_stt/daemon.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import os
+import platform
 import signal
 import subprocess
 import sys
@@ -245,7 +246,8 @@ def _spawn_background() -> bool:
                 stdout=log_handle,
                 stderr=log_handle,
                 stdin=subprocess.DEVNULL,
-                start_new_session=(os.name != "nt"),
+                # Linux/X11 hotkeys fail if we detach into a new session.
+                start_new_session=(os.name != "nt" and platform.system() == "Darwin"),
                 creationflags=creationflags,
             )
 


### PR DESCRIPTION
## Summary\n- avoid new session on Linux background daemon to keep X11 hotkeys working\n\n## Testing\n- uv run ruff check .\n- uv run python -m unittest discover -s tests\n\nFixes #10