### PR TITLE
Fix Linux hotkey normalization

### DIFF
--- a/src/claude_stt/hotkey.py
+++ b/src/claude_stt/hotkey.py
@@ -172,6 +172,15 @@ class HotkeyListener:
             return keyboard.KeyCode.from_char(key.char.lower())
 
         if hasattr(key, "vk") and key.vk is not None:
+            # Normalize KeyCode(vk=...) to Key enum when possible (Linux/X11).
+            try:
+                for member in keyboard.Key:
+                    value = getattr(member, "value", None)
+                    if hasattr(value, "vk") and value.vk == key.vk:
+                        return member
+            except Exception:
+                pass
+
             if platform.system() == "Darwin":
                 mac_vk_map = {
                     49: keyboard.Key.space,


### PR DESCRIPTION
## Summary\n- normalize KeyCode(vk=...) to pynput Key enum for reliable hotkey matching on X11\n\n## Testing\n- uv run ruff check .\n- uv run python -m unittest discover -s tests\n\nFixes #9