### PR TITLE
Warn when running under WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Settings stored in `~/.claude/plugins/claude-stt/config.toml`.
 | Platform | Additional Requirements |
 |----------|------------------------|
 | **macOS** | Accessibility permissions (System Settings > Privacy & Security) |
-| **Linux** | xdotool for window management; X11 recommended (Wayland has limitations) |
+| **Linux** | xdotool for window management; X11 recommended (Wayland has limitations); WSL not supported |
 | **Windows** | pywin32 for window tracking |
 
 ---
@@ -137,6 +137,7 @@ claude-stt start --background
 | Whisper dependencies missing | Run `/claude-stt:setup --with-whisper`, or `uv sync --directory $CLAUDE_PLUGIN_ROOT --extra whisper`, or `python $CLAUDE_PLUGIN_ROOT/scripts/exec.py -m pip install .[whisper]` |
 | Hotkey not triggering | Check for conflicts with other apps. Try `/claude-stt:config` to change hotkey |
 | Text going to wrong window | Plugin tracks original window — ensure Claude Code was focused when recording started |
+| Running under WSL | Not supported; use native Windows or Linux |
 
 ### Logging
 

--- a/src/claude_stt/config.py
+++ b/src/claude_stt/config.py
@@ -242,3 +242,15 @@ def is_wayland() -> bool:
     if get_platform() != "linux":
         return False
     return os.environ.get("XDG_SESSION_TYPE") == "wayland"
+
+
+def is_wsl() -> bool:
+    """Check if running under Windows Subsystem for Linux."""
+    if get_platform() != "linux":
+        return False
+    if os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"):
+        return True
+    try:
+        return "microsoft" in Path("/proc/version").read_text().lower()
+    except OSError:
+        return False

--- a/src/claude_stt/setup.py
+++ b/src/claude_stt/setup.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from typing import Sequence
 
-from .config import Config, get_platform, is_wayland
+from .config import Config, get_platform, is_wayland, is_wsl
 from .daemon import is_daemon_running
 from .engine_factory import build_engine
 from .errors import EngineError, HotkeyError
@@ -203,6 +203,9 @@ def _check_platform_requirements() -> None:
             "System Settings > Privacy & Security > Accessibility."
         )
     elif platform == "linux":
+        if is_wsl():
+            _print_warn("WSL detected; global hotkeys and window focus are not supported.")
+            _print_warn("Use native Windows or a full Linux desktop session.")
         if is_wayland():
             _print_warn("Wayland detected; hotkeys/injection may be limited.")
         if shutil.which("xdotool") is None:


### PR DESCRIPTION
## Summary\n- detect WSL during setup and warn about unsupported hotkeys/window focus\n- document WSL as unsupported in requirements and troubleshooting\n\n## Testing\n- uv run ruff check .\n- uv run python -m unittest discover -s tests\n\nFixes #1