### PR TITLE
docs: add daemon architecture and local dev workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ temp/
 .agents/
 .ralph/
 
+# Local Claude Code notes (not for upstream)
+CLAUDE.local.md
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,22 @@ uv run ruff check src/
 
 **Daemon-based design**: A background process (`STTDaemon`) runs continuously, listening for hotkey events and coordinating audio capture, transcription, and text output.
 
+### Global Daemon Behavior
+
+The daemon is **system-wide**, not per-session:
+- Runs as a standalone background process independent of any Claude Code session
+- Listens for hotkeys globally via pynput (works when any window is focused)
+- Survives Claude sessions closing — persists until explicitly stopped or reboot
+- State stored in `~/.claude/plugins/claude-stt/`:
+  - `daemon.pid` — JSON with PID, command, creation timestamp
+  - `config.toml` — User settings
+  - `daemon.log` — Runtime logs
+
+**Visibility:** The daemon doesn't appear in `/stats` or any Claude UI. Check status via:
+- `/claude-stt:status` from any Claude session
+- `ps aux | grep claude_stt`
+- `cat ~/.claude/plugins/claude-stt/daemon.pid`
+
 ### Core Components
 
 - `daemon.py` - Process management (start/stop/status, PID file handling, background spawning)
@@ -48,12 +64,85 @@ Hotkey press → AudioRecorder.start() → [user speaks] → Hotkey release
 
 Transcription runs in a dedicated worker thread to avoid blocking the hotkey listener.
 
+### Threading Model & Latency-Critical Path
+
+The daemon uses multiple threads:
+1. **Main thread** — Simple polling loop (`time.sleep(0.1)`) that checks max recording time
+2. **Hotkey thread** — pynput listener runs its own event loop (CFRunLoop on macOS)
+3. **Transcription thread** — Worker thread that processes audio queue
+
+**Latency-critical path:** The recording start/stop callbacks (`_on_recording_start`, `_on_recording_stop`) are invoked directly by pynput's hotkey thread — they do NOT go through the main loop. This means:
+- Any additions (e.g., status indicators) should not block these callbacks
+- The main loop's 100ms sleep does not affect hotkey responsiveness
+- Sound effects are played synchronously in the callback (potential optimization: async playback)
+
 ### Plugin Structure
 
 - `commands/` - Slash commands (setup, start, stop, status, config) as markdown files
 - `hooks/hooks.json` - Claude Code plugin hooks
 - `scripts/setup.py` - Bootstrap script that handles venv creation, dependency install, model download
 - `.claude-plugin/plugin.json` - Plugin metadata
+
+## Local Development vs Plugin Install
+
+There are two ways claude-stt can be installed, and understanding the difference is critical for development.
+
+### Two Installation Locations
+
+| Installation | Location | When Used |
+|--------------|----------|-----------|
+| **Plugin cache** | `~/.claude/plugins/cache/jarrodwatts-claude-stt/claude-stt/X.Y.Z/` | Normal usage via `/plugin install` |
+| **Local dev** | Your clone, e.g. `/Users/you/projects/claude-stt/` | Development via `claude --plugin-dir .` |
+
+### Isolation
+
+Each installation has its **own `.venv`** (created inside its directory by `scripts/setup.py`), but they **share config**:
+
+| Component | Isolated? | Location |
+|-----------|-----------|----------|
+| Code & .venv | Yes | Inside each plugin root |
+| config.toml | **Shared** | `~/.claude/plugins/claude-stt/` |
+| daemon.pid | **Shared** | `~/.claude/plugins/claude-stt/` |
+| daemon.log | **Shared** | `~/.claude/plugins/claude-stt/` |
+
+### Switching to Local Development
+
+```bash
+# 1. Stop any running daemon (from plugin cache)
+/claude-stt:stop
+
+# 2. Verify it's stopped
+ps aux | grep claude_stt  # Should show nothing
+
+# 3. Exit current Claude session
+exit
+
+# 4. Start Claude with local plugin
+cd /path/to/your/claude-stt
+claude --plugin-dir .
+
+# 5. Setup local version (creates .venv in project dir)
+/claude-stt:setup
+
+# 6. Start daemon from YOUR local code
+/claude-stt:start
+
+# 7. Verify it's running from local (check the path in output)
+cat ~/.claude/plugins/claude-stt/daemon.pid
+```
+
+### Switching Back to Plugin Cache
+
+```bash
+/claude-stt:stop
+exit
+claude  # No --plugin-dir flag
+/claude-stt:start
+```
+
+### Key Gotcha
+
+Only **one daemon can run at a time** (they share `daemon.pid`). Always stop the existing daemon before switching installations.
 
 ## Version Bumps
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,23 @@ claude-stt start --background
 
 ---
 
+## How the Daemon Works
+
+The STT daemon runs as a **system-wide background process**, independent of any Claude Code session:
+
+- **Persists** until explicitly stopped (`/claude-stt:stop`) or system reboot
+- **Listens globally** for hotkeys (works when any window is focused)
+- **Status and logs** stored in `~/.claude/plugins/claude-stt/`
+
+Check if it's running:
+```bash
+ps aux | grep claude_stt
+# Or
+cat ~/.claude/plugins/claude-stt/daemon.pid
+```
+
+---
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -138,6 +155,7 @@ claude-stt start --background
 | Hotkey not triggering | Check for conflicts with other apps. Try `/claude-stt:config` to change hotkey |
 | Text going to wrong window | Plugin tracks original window — ensure Claude Code was focused when recording started |
 | Running under WSL | Not supported; use native Windows or Linux |
+| Daemon still running after closing Claude | This is expected — the daemon is system-wide and persists. Stop it with `/claude-stt:stop` or `kill $(cat ~/.claude/plugins/claude-stt/daemon.pid \| jq -r .pid)` |
 
 ### Logging
 


### PR DESCRIPTION
Add documentation for contributors

CLAUDE.md:
- Add "Global Daemon Behavior" section (system-wide process, state files)
- Add "Threading Model" section (latency-critical path analysis)
- Add "Local Development vs Plugin Install" workflow

README.md:
- Add "How the Daemon Works" section explaining daemon persistence
- Add troubleshooting entry for daemon still running after closing Claude

Also add CLAUDE.local.md to .gitignore for contributor-specific notes.