### PR TITLE
feat: add moonshine_models_dir config for multilingual ONNX models

### DIFF
--- a/src/claude_stt/config.py
+++ b/src/claude_stt/config.py
@@ -35,6 +35,7 @@ class Config:
     # Engine settings
     engine: Literal["moonshine", "whisper"] = "moonshine"
     moonshine_model: str = "moonshine/base"
+    moonshine_models_dir: str | None = None  # Local ONNX model directory path
     whisper_model: str = "medium"
 
     # Audio settings
@@ -95,6 +96,7 @@ class Config:
                 mode=stt_config.get("mode", cls.mode),
                 engine=stt_config.get("engine", cls.engine),
                 moonshine_model=stt_config.get("moonshine_model", cls.moonshine_model),
+                moonshine_models_dir=stt_config.get("moonshine_models_dir", cls.moonshine_models_dir),
                 whisper_model=stt_config.get("whisper_model", cls.whisper_model),
                 sample_rate=stt_config.get("sample_rate", cls.sample_rate),
                 max_recording_seconds=stt_config.get(
@@ -128,8 +130,7 @@ class Config:
         config_path = self.get_config_path()
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        data = {
-            "claude-stt": {
+        stt_data: dict = {
                 "hotkey": self.hotkey,
                 "mode": self.mode,
                 "engine": self.engine,
@@ -137,11 +138,16 @@ class Config:
                 "whisper_model": self.whisper_model,
                 "sample_rate": self.sample_rate,
                 "max_recording_seconds": self.max_recording_seconds,
-                "audio_device": self.audio_device,
                 "output_mode": self.output_mode,
                 "sound_effects": self.sound_effects,
-            }
         }
+        # TOML cannot serialize None; only include optional fields when set
+        if self.moonshine_models_dir is not None:
+            stt_data["moonshine_models_dir"] = self.moonshine_models_dir
+        if self.audio_device is not None:
+            stt_data["audio_device"] = self.audio_device
+
+        data = {"claude-stt": stt_data}
 
         temp_file = None
         try:
@@ -186,6 +192,15 @@ class Config:
                 "Unknown moonshine_model '%s'; using as provided",
                 self.moonshine_model,
             )
+
+        if self.moonshine_models_dir is not None:
+            expanded = Path(self.moonshine_models_dir).expanduser().resolve()
+            self.moonshine_models_dir = str(expanded)
+            if not expanded.is_dir():
+                logger.warning(
+                    "moonshine_models_dir '%s' does not exist; model loading may fail",
+                    self.moonshine_models_dir,
+                )
 
         if not isinstance(self.whisper_model, str) or not self.whisper_model.strip():
             logger.warning("Invalid whisper_model; defaulting to 'medium'")

--- a/src/claude_stt/engine_factory.py
+++ b/src/claude_stt/engine_factory.py
@@ -10,7 +10,10 @@ from .errors import EngineError
 def build_engine(config: Config) -> STTEngine:
     """Create an engine instance for the configured engine."""
     if config.engine == "moonshine":
-        return MoonshineEngine(model_name=config.moonshine_model)
+        return MoonshineEngine(
+            model_name=config.moonshine_model,
+            models_dir=config.moonshine_models_dir,
+        )
     if config.engine == "whisper":
         return WhisperEngine(model_name=config.whisper_model)
     raise EngineError(f"Unknown engine '{config.engine}'")

--- a/src/claude_stt/engines/moonshine.py
+++ b/src/claude_stt/engines/moonshine.py
@@ -28,13 +28,17 @@ class MoonshineEngine:
         - moonshine/base: ~400MB, better accuracy
     """
 
-    def __init__(self, model_name: str = "moonshine/base"):
+    def __init__(self, model_name: str = "moonshine/base", models_dir: str | None = None):
         """Initialize the Moonshine engine.
 
         Args:
             model_name: Model to use ("moonshine/tiny" or "moonshine/base").
+            models_dir: Local directory containing ONNX model files.
+                        When set, loads models from this path instead of
+                        downloading from HuggingFace.
         """
         self.model_name = model_name
+        self.models_dir = models_dir
         self._model: Optional[object] = None
         self._logger = logging.getLogger(__name__)
 
@@ -57,7 +61,10 @@ class MoonshineEngine:
             return True
 
         try:
-            self._model = _MoonshineModel(model_name=self.model_name)
+            kwargs = {"model_name": self.model_name}
+            if self.models_dir is not None:
+                kwargs["models_dir"] = self.models_dir
+            self._model = _MoonshineModel(**kwargs)
             return True
         except Exception:
             self._logger.exception("Failed to load Moonshine model")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,19 @@ class ConfigTests(unittest.TestCase):
         self.assertEqual(config.max_recording_seconds, 1)
         self.assertEqual(config.sample_rate, 16000)
 
+    def test_moonshine_models_dir_default_is_none(self):
+        config = Config()
+        self.assertIsNone(config.moonshine_models_dir)
+
+    def test_moonshine_models_dir_tilde_expansion(self):
+        config = Config(moonshine_models_dir="~/my-models").validate()
+        self.assertNotIn("~", config.moonshine_models_dir)
+        self.assertTrue(config.moonshine_models_dir.startswith("/"))
+
+    def test_moonshine_models_dir_none_skipped_in_validate(self):
+        config = Config(moonshine_models_dir=None).validate()
+        self.assertIsNone(config.moonshine_models_dir)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine_factory.py
+++ b/tests/test_engine_factory.py
@@ -2,6 +2,7 @@ import unittest
 
 from claude_stt.config import Config
 from claude_stt.engine_factory import build_engine
+from claude_stt.engines.moonshine import MoonshineEngine
 from claude_stt.engines.whisper import WhisperEngine
 from claude_stt.errors import EngineError
 
@@ -18,6 +19,18 @@ class EngineFactoryTests(unittest.TestCase):
         config = Config(engine="whisper")
         engine = build_engine(config)
         self.assertIsInstance(engine, WhisperEngine)
+
+    def test_moonshine_engine_receives_models_dir(self):
+        config = Config(engine="moonshine", moonshine_models_dir="/tmp/my-models")
+        engine = build_engine(config)
+        self.assertIsInstance(engine, MoonshineEngine)
+        self.assertEqual(engine.models_dir, "/tmp/my-models")
+
+    def test_moonshine_engine_models_dir_none_by_default(self):
+        config = Config(engine="moonshine")
+        engine = build_engine(config)
+        self.assertIsInstance(engine, MoonshineEngine)
+        self.assertIsNone(engine.models_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `moonshine_models_dir` config field to support loading language-specific Moonshine ONNX models from a local directory
- When set, the path is passed through to `MoonshineOnnxModel(models_dir=...)`, bypassing the hardcoded HuggingFace repo (`UsefulSensors/moonshine`)
- Path is expanded (`~`) and validated during config validation; `None` (default) preserves existing behavior

### Usage

```toml
[claude-stt]
engine = "moonshine"
moonshine_model = "moonshine/tiny"
moonshine_models_dir = "~/.cache/moonshine-tiny-ko"
```

### Files changed

| File | Change |
|------|--------|
| `config.py` | New `moonshine_models_dir` field + load/save/validate |
| `moonshine.py` | Accept and forward `models_dir` to `MoonshineOnnxModel` |
| `engine_factory.py` | Pass `models_dir` from config to engine |
| `test_config.py` | 3 new tests (default, tilde expansion, None passthrough) |
| `test_engine_factory.py` | 2 new tests (models_dir forwarding, default None) |

Closes #22

## Test plan

- [x] `uv run python -m unittest discover -s tests` — all 16 tests pass
- [ ] Manual: set `moonshine_models_dir` to a local path with Korean ONNX files, verify model loads from that directory

Generated with [Claude Code](https://claude.com/claude-code)
