### PR TITLE
feat: add mlx-whisper engine for Apple Silicon GPU acceleration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "claude-stt"
 version = "0.1.0"
 description = "Speech-to-text input for Claude Code with live streaming dictation"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 license = "MIT"
 authors = [
     { name = "Jarrod Watts", email = "jarrod@jarrodwatts.com" }
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.optional-dependencies]
 whisper = ["faster-whisper>=1.0"]
+mlx-whisper = ["mlx-whisper>=0.4"]
 macos = ["pyobjc-framework-Cocoa"]
 windows = ["pywin32"]
 dev = ["pytest", "ruff"]

--- a/src/claude_stt/config.py
+++ b/src/claude_stt/config.py
@@ -33,9 +33,10 @@ class Config:
     mode: Literal["push-to-talk", "toggle"] = "toggle"
 
     # Engine settings
-    engine: Literal["moonshine", "whisper"] = "moonshine"
+    engine: Literal["moonshine", "whisper", "mlx-whisper"] = "moonshine"
     moonshine_model: str = "moonshine/base"
     whisper_model: str = "medium"
+    mlx_whisper_model: str = "mlx-community/whisper-large-v3-turbo"
 
     # Audio settings
     sample_rate: int = 16000
@@ -96,6 +97,7 @@ class Config:
                 engine=stt_config.get("engine", cls.engine),
                 moonshine_model=stt_config.get("moonshine_model", cls.moonshine_model),
                 whisper_model=stt_config.get("whisper_model", cls.whisper_model),
+                mlx_whisper_model=stt_config.get("mlx_whisper_model", cls.mlx_whisper_model),
                 sample_rate=stt_config.get("sample_rate", cls.sample_rate),
                 max_recording_seconds=stt_config.get(
                     "max_recording_seconds", cls.max_recording_seconds
@@ -135,6 +137,7 @@ class Config:
                 "engine": self.engine,
                 "moonshine_model": self.moonshine_model,
                 "whisper_model": self.whisper_model,
+                "mlx_whisper_model": self.mlx_whisper_model,
                 "sample_rate": self.sample_rate,
                 "max_recording_seconds": self.max_recording_seconds,
                 "audio_device": self.audio_device,
@@ -174,7 +177,7 @@ class Config:
             logger.warning("Invalid mode '%s'; defaulting to 'toggle'", self.mode)
             self.mode = "toggle"
 
-        if self.engine not in ("moonshine", "whisper"):
+        if self.engine not in ("moonshine", "whisper", "mlx-whisper"):
             logger.warning("Invalid engine '%s'; defaulting to 'moonshine'", self.engine)
             self.engine = "moonshine"
 
@@ -190,6 +193,10 @@ class Config:
         if not isinstance(self.whisper_model, str) or not self.whisper_model.strip():
             logger.warning("Invalid whisper_model; defaulting to 'medium'")
             self.whisper_model = "medium"
+
+        if not isinstance(self.mlx_whisper_model, str) or not self.mlx_whisper_model.strip():
+            logger.warning("Invalid mlx_whisper_model; defaulting to 'mlx-community/whisper-large-v3-turbo'")
+            self.mlx_whisper_model = "mlx-community/whisper-large-v3-turbo"
 
         if self.output_mode not in ("injection", "clipboard", "auto"):
             logger.warning("Invalid output_mode '%s'; defaulting to 'auto'", self.output_mode)

--- a/src/claude_stt/engine_factory.py
+++ b/src/claude_stt/engine_factory.py
@@ -2,6 +2,7 @@
 
 from .config import Config
 from .engines import STTEngine
+from .engines.mlx_whisper import MlxWhisperEngine
 from .engines.moonshine import MoonshineEngine
 from .engines.whisper import WhisperEngine
 from .errors import EngineError
@@ -13,4 +14,6 @@ def build_engine(config: Config) -> STTEngine:
         return MoonshineEngine(model_name=config.moonshine_model)
     if config.engine == "whisper":
         return WhisperEngine(model_name=config.whisper_model)
+    if config.engine == "mlx-whisper":
+        return MlxWhisperEngine(model_name=config.mlx_whisper_model)
     raise EngineError(f"Unknown engine '{config.engine}'")

--- a/src/claude_stt/engines/mlx_whisper.py
+++ b/src/claude_stt/engines/mlx_whisper.py
@@ -1,0 +1,51 @@
+"""MLX Whisper STT engine - GPU-accelerated speech-to-text for Apple Silicon."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+
+_mlx_whisper_available = False
+
+try:
+    import mlx_whisper as _mlx_whisper
+
+    _mlx_whisper_available = True
+except ImportError:
+    _mlx_whisper = None
+
+
+class MlxWhisperEngine:
+    """Whisper speech-to-text engine backed by mlx-whisper for Apple Silicon."""
+
+    def __init__(self, model_name: str = "mlx-community/whisper-large-v3-turbo"):
+        self.model_name = model_name
+        self._logger = logging.getLogger(__name__)
+
+    def is_available(self) -> bool:
+        return _mlx_whisper_available
+
+    def load_model(self) -> bool:
+        if not self.is_available():
+            return False
+        # mlx-whisper loads the model on first transcribe call and caches it.
+        return True
+
+    def transcribe(self, audio: np.ndarray, sample_rate: int = 16000) -> str:
+        if not self.is_available():
+            return ""
+        try:
+            if audio.dtype != np.float32:
+                audio = audio.astype(np.float32)
+
+            result = _mlx_whisper.transcribe(
+                audio,
+                path_or_hf_repo=self.model_name,
+            )
+            text = result.get("text", "")
+            return text.strip()
+        except Exception:
+            self._logger.exception("MLX Whisper transcription failed")
+            return ""


### PR DESCRIPTION
## Summary

- Adds **mlx-whisper** as a new STT engine option, leveraging Apple Silicon's Metal GPU for significantly faster transcription
- Introduces `engine = "mlx-whisper"` configuration alongside existing `moonshine` and `whisper` engines
- Defaults to `mlx-community/whisper-large-v3-turbo` model — fast inference with full multilingual support and punctuation

## Motivation

The existing `whisper` engine uses `faster-whisper` with CTranslate2, which runs on **CPU only** on macOS (no CUDA). On Apple Silicon Macs, this leaves the Metal GPU unused, resulting in slow transcription — especially with larger models like `large-v3` or `turbo`.

`mlx-whisper` solves this by running Whisper natively on Apple's Metal GPU via the MLX framework, delivering **dramatically faster** transcription while maintaining the same quality (punctuation, multilingual support).

## Changes

| File | Change |
|------|--------|
| `src/claude_stt/engines/mlx_whisper.py` | New engine class implementing `STTEngine` protocol (~50 lines) |
| `src/claude_stt/engine_factory.py` | Added `mlx-whisper` engine branch |
| `src/claude_stt/config.py` | Added `mlx-whisper` to engine literal, `mlx_whisper_model` field, load/save/validation |
| `pyproject.toml` | Added `mlx-whisper` optional dependency, relaxed Python version constraint to `>=3.10` |

## Usage

```toml
[claude-stt]
engine = "mlx-whisper"
mlx_whisper_model = "mlx-community/whisper-large-v3-turbo"
```

Install with: `pip install -e ".[mlx-whisper]"`

## Test plan

- [x] Smoke test: engine loads, `is_available()` returns `True`
- [x] Tested live transcription in German with punctuation — works correctly
- [x] Verified significant speed improvement over `faster-whisper` on Apple Silicon
- [ ] Verify graceful fallback when `mlx-whisper` is not installed (`is_available()` returns `False`)
- [ ] Test with different model variants (e.g., `mlx-community/whisper-large-v3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)